### PR TITLE
Fix groupBuyProduct value binding

### DIFF
--- a/src/app/groupbuy/editgroupbuy/[id]/editgroupdefaultfield.tsx
+++ b/src/app/groupbuy/editgroupbuy/[id]/editgroupdefaultfield.tsx
@@ -47,7 +47,7 @@ export default function Editgroupdefaultfield({
           required
           id="groupBuyProduct"
           name="groupBuyProduct"
-          value={groupDefault.groupBuyOwner}
+          value={groupDefault.groupBuyProduct}
           onChange={handleGroupDefault}
         />
       </div>


### PR DESCRIPTION
## Summary
- correct the value binding for `groupBuyProduct` in the edit form

## Testing
- `npx next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68491701d938832693dd68da48d21a13