### PR TITLE
Add Jest and basic test

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,15 @@
+import { cn } from '../src/lib/utils'
+
+describe('cn utility', () => {
+  it('merges class names with spaces', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('handles undefined values', () => {
+    expect(cn('foo', undefined)).toBe('foo')
+  })
+
+  it('merges tailwind classes and resolves conflicts', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+})

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'jest'
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json'
+    }
+  }
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/cache": "^11.11.0",
@@ -45,6 +46,9 @@
     "zustand": "^4.5.3"
   },
   "devDependencies": {
-    "@types/uuid": "^10.0.0"
+    "@types/uuid": "^10.0.0",
+    "@types/jest": "^29.5.6",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  }
+}


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest
- add a Jest config using `tsconfig.jest.json`
- create sample test for `cn` utility
- add `test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684917256b688326b283501437b879b6